### PR TITLE
Change read me to use the direct install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ To use with Claude Desktop, add this server configuration:
 [mcp-get](https://github.com/michaellatman/mcp-get) A command-line tool for installing and managing Model Context Protocol (MCP) servers.
 
 ```shell 
-npx @michaellatman/mcp-get@latest list
-
-@kimtaeyoon83/mcp-server-youtube-transcript │ This is an MCP server that allows you to dir... │ Freddie (https://github.com/kimtaeyoon83) │ MIT
+npx @michaellatman/mcp-get@latest install @kimtaeyoon83/mcp-server-youtube-transcript
 ```
 
 ## Awesome-mcp-servers 


### PR DESCRIPTION
Update the `README.md` file to use the direct install command.

* Replace the existing command `npx @michaellatman/mcp-get@latest list` with `npx @michaellatman/mcp-get@latest install @kimtaeyoon83/mcp-server-youtube-transcript` in the "Install via tool" section.
* Remove the example output of the `list` command.

