### PR TITLE
Add Smithery CLI Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # YouTube Transcript Server
 
+[![smithery badge](https://smithery.ai/badge/@kimtaeyoon83/mcp-server-youtube-transcript)](https://smithery.ai/protocol/@kimtaeyoon83/mcp-server-youtube-transcript)
+
 A Model Context Protocol server that enables retrieval of transcripts from YouTube videos. This server provides direct access to video captions and subtitles through a simple interface.
+
+### Installing via Smithery
+
+To install YouTube Transcript Server for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@kimtaeyoon83/mcp-server-youtube-transcript):
+
+```bash
+npx @smithery/cli install @kimtaeyoon83/mcp-server-youtube-transcript --client claude
+```
 
 ## Components
 


### PR DESCRIPTION
This PR adds installation instructions to automatically install YouTube Transcript Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP. Also, it adds a badge to show the number of installations from Smithery.