### PR TITLE
fix: drop structuredContent to fix [object Object] in Claude Code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,6 +1168,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2449,6 +2450,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,15 +42,6 @@ const TOOLS: Tool[] = [
       },
       required: ["url"]
     },
-    // OutputSchema describes structuredContent format for Claude Code
-    outputSchema: {
-      type: "object",
-      properties: {
-        meta: { type: "string", description: "Title | Author | Subs | Views | Date" },
-        content: { type: "string" }
-      },
-      required: ["content"]
-    },
     annotations: {
       title: "Get Transcript",
       readOnlyHint: true,
@@ -299,16 +290,12 @@ class TranscriptServer {
             transcript += '\n\n[Note: No chapter markers found. If summarizing, please exclude any sponsored segments or ads from the summary.]';
           }
 
-          // Claude Code v2.0.21+ needs structuredContent for proper display
+          const metaHeader = `${result.metadata.title} | ${result.metadata.author} | ${result.metadata.subscriberCount} subs | ${result.metadata.viewCount} views | ${result.metadata.publishDate}`;
           return {
             content: [{
               type: "text" as const,
-              text: transcript
-            }],
-            structuredContent: {
-              meta: `${result.metadata.title} | ${result.metadata.author} | ${result.metadata.subscriberCount} subs | ${result.metadata.viewCount} views | ${result.metadata.publishDate}`,
-              content: transcript.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ')
-            }
+              text: `${metaHeader}\n\n${transcript}`
+            }]
           };
         } catch (error) {
           console.error('Transcript extraction failed:', error);


### PR DESCRIPTION
## Summary

- Removes `structuredContent` object and `outputSchema` from the `get_transcript` tool response
- Inlines video metadata (title, author, subs, views, date) as a header line in the standard `content` text array

## Problem

Since the metadata PR (#24, Dec 2025), the tool response includes a `structuredContent` object alongside the `content` text array. MCP clients (including Claude Code) coerce this object to string, producing `[object Object]` instead of the actual transcript.

## Fix

The metadata is valuable context, so rather than dropping it entirely, it's prepended as a readable header line in the text response:

```
Video Title | Author | 10K subs | 50K views | 2026-03-16

[transcript text here...]
```

This uses the universally supported `content` text array format that all MCP clients handle correctly.

## Test plan

- [x] `npm run build` — clean compile, no errors
- [ ] Verify transcript output includes metadata header followed by transcript text
- [ ] Confirm no `[object Object]` in Claude Code or other MCP clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)