### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ The server implements robust error handling for common scenarios:
 - Language availability issues
 - Network errors
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kimtaeyoon83-mcp-server-youtube-transcript).
+
 ## Usage Examples
 
 1. Get transcript by video URL:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kimtaeyoon83-mcp-server-youtube-transcript)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 설명서
* README에 호스팅된 배포 섹션이 추가되어 외부에서 호스팅되는 MCP 서버 버전에 대한 정보 및 관련 리소스 링크를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->