### PR TITLE
feat: Add analyze_video tool using TwelveLabs Pegasus

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ npx -y @smithery/cli install @kimtaeyoon83/mcp-server-youtube-transcript --clien
     - `include_timestamps` (boolean, optional, default: false): Include timestamps in output (e.g., '[0:05] text')
     - `strip_ads` (boolean, optional, default: true): Filter out sponsorships, ads, and promotional content from transcript based on chapter markers
 
+- **analyze_video** (optional, requires a TwelveLabs API key)
+  - Analyze a video with [TwelveLabs](https://twelvelabs.io) Pegasus, a video-understanding model. Unlike `get_transcript`, this reasons over what is *shown* on screen, so it produces useful summaries and answers even for videos with little or no speech (demos, gameplay, b-roll, music videos).
+  - Inputs:
+    - `url` (string, required): A publicly reachable **direct video URL** (e.g. an `.mp4`/`.mov`/`.webm` link or a pre-signed URL). TwelveLabs fetches the file server-side, so a YouTube watch page URL will not work — it serves HTML, not a raw video stream.
+    - `prompt` (string, optional): Instruction or question for the model (e.g. `"Summarize this video in 3 sentences"` or `"What products are shown?"`). Defaults to a general summary.
+    - `model` (string, optional, default: `"pegasus1.2"`): Pegasus model to use (`"pegasus1.2"` or `"pegasus1.5"`).
+    - `max_tokens` (number, optional, default: 2048): Maximum response length in tokens.
+  - Requires the `TWELVELABS_API_KEY` environment variable. The transcript tool works without it; analysis is fully opt-in. Grab a free key at [twelvelabs.io](https://twelvelabs.io) — there's a generous free tier.
+
 ## Key Features
 
 - Support for multiple video URL formats (including YouTube Shorts)
@@ -48,6 +57,22 @@ To use with Claude Desktop, add this server configuration:
     "youtube-transcript": {
       "command": "npx",
       "args": ["-y", "@kimtaeyoon83/mcp-server-youtube-transcript"]
+    }
+  }
+}
+```
+
+To enable the optional `analyze_video` tool, add your TwelveLabs API key:
+
+```json
+{
+  "mcpServers": {
+    "youtube-transcript": {
+      "command": "npx",
+      "args": ["-y", "@kimtaeyoon83/mcp-server-youtube-transcript"],
+      "env": {
+        "TWELVELABS_API_KEY": "your-twelvelabs-api-key"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",
-        "mcp-evals": "^1.0.18"
+        "mcp-evals": "^1.0.18",
+        "twelvelabs-js": "^1.2.8"
       },
       "bin": {
         "mcp-server-youtube-transcript": "dist/index.js"
@@ -759,6 +760,26 @@
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
@@ -790,6 +811,30 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bytes": {
@@ -1143,6 +1188,15 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/eventsource": {
@@ -1534,6 +1588,26 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -1947,6 +2021,15 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2002,6 +2085,22 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/rechoir": {
@@ -2066,6 +2165,26 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2253,6 +2372,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2338,6 +2466,38 @@
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
+    "node_modules/twelvelabs-js": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/twelvelabs-js/-/twelvelabs-js-1.2.8.tgz",
+      "integrity": "sha512-LFOIp0zUA1YmOGW2Q8ugav81ln0XTsyPpLki4iCGiJFfsnWx9by47FUbLf2g08EfNwZp8n0G44cTtqjPGn5mSw==",
+      "dependencies": {
+        "form-data": "^4.0.0",
+        "form-data-encoder": "^4.0.2",
+        "formdata-node": "^6.0.3",
+        "node-fetch": "^2.7.0",
+        "qs": "^6.13.1",
+        "readable-stream": "^4.5.2",
+        "url-join": "4.0.1"
+      }
+    },
+    "node_modules/twelvelabs-js/node_modules/form-data-encoder": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+      "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/twelvelabs-js/node_modules/formdata-node": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
+      "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -2387,6 +2547,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.9.0",
-    "mcp-evals": "^1.0.18"
+    "mcp-evals": "^1.0.18",
+    "twelvelabs-js": "^1.2.8"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -13,11 +13,20 @@ const get_transcriptEval: EvalFunction = {
     }
 };
 
+const analyze_videoEval: EvalFunction = {
+    name: "analyze_video Tool Evaluation",
+    description: "Evaluates prompt-based video analysis with TwelveLabs Pegasus from a direct video URL",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Summarize the video at https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4 in one sentence.");
+        return JSON.parse(result);
+    }
+};
+
 const config: EvalConfig = {
     model: openai("gpt-4"),
-    evals: [get_transcriptEval]
+    evals: [get_transcriptEval, analyze_videoEval]
 };
-  
+
 export default config;
-  
-export const evals = [get_transcriptEval];
+
+export const evals = [get_transcriptEval, analyze_videoEval];

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { getSubtitles, AdChapter, CaptionTrack } from './youtube-fetcher.js';
+import { analyzeVideo, PegasusModel } from './twelvelabs-analyzer.js';
 
 // Define tool configurations
 const TOOLS: Tool[] = [
@@ -53,6 +54,49 @@ const TOOLS: Tool[] = [
     },
     annotations: {
       title: "Get Transcript",
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
+  },
+  {
+    name: "analyze_video",
+    description: "Analyze a video with TwelveLabs Pegasus (video-understanding model) to generate a summary or answer a question. Unlike get_transcript, this reasons over what is shown on screen, so it works for videos with little or no speech. Requires a TWELVELABS_API_KEY and a publicly reachable direct video URL (e.g. .mp4/.mov/.webm); a YouTube watch page URL is NOT a direct media file and will not work.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: {
+          type: "string",
+          description: "Publicly reachable direct video URL (e.g. an .mp4/.mov/.webm link or pre-signed URL). Not a YouTube watch page."
+        },
+        prompt: {
+          type: "string",
+          description: "Instruction or question for the model (e.g. 'Summarize this video in 3 sentences' or 'What products are shown?'). Default: a general summary.",
+          default: "Summarize this video, highlighting the main topic, key events, and conclusion."
+        },
+        model: {
+          type: "string",
+          enum: ["pegasus1.2", "pegasus1.5"],
+          description: "Pegasus model to use. Default: pegasus1.2",
+          default: "pegasus1.2"
+        },
+        max_tokens: {
+          type: "number",
+          description: "Maximum response length in tokens (2-4096 for pegasus1.2). Default: 2048",
+          default: 2048
+        }
+      },
+      required: ["url"]
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        meta: { type: "string", description: "Model | finish reason" },
+        content: { type: "string", description: "Generated analysis text" }
+      },
+      required: ["content"]
+    },
+    annotations: {
+      title: "Analyze Video (TwelveLabs Pegasus)",
       readOnlyHint: true,
       openWorldHint: true,
     },
@@ -320,6 +364,67 @@ class TranscriptServer {
           throw new McpError(
             ErrorCode.InternalError,
             `Failed to process transcript: ${(error as Error).message}`
+          );
+        }
+      }
+
+      case "analyze_video": {
+        const {
+          url: input,
+          prompt = "Summarize this video, highlighting the main topic, key events, and conclusion.",
+          model = "pegasus1.2",
+          max_tokens = 2048,
+        } = args;
+
+        if (!input || typeof input !== 'string') {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            'URL parameter is required and must be a string'
+          );
+        }
+        if (typeof prompt !== 'string') {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            'Prompt must be a string'
+          );
+        }
+        if (model !== 'pegasus1.2' && model !== 'pegasus1.5') {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `Invalid model '${model}'. Must be 'pegasus1.2' or 'pegasus1.5'.`
+          );
+        }
+
+        try {
+          console.log(`Analyzing video with TwelveLabs ${model}: ${input}`);
+          const result = await analyzeVideo({
+            url: input,
+            prompt,
+            model: model as PegasusModel,
+            maxTokens: typeof max_tokens === 'number' ? max_tokens : undefined,
+          });
+          console.log(`Analysis complete (${result.text.length} chars, finish: ${result.finishReason ?? 'n/a'})`);
+
+          return {
+            content: [{
+              type: "text" as const,
+              text: result.text
+            }],
+            structuredContent: {
+              meta: `${result.model}${result.finishReason ? ` | ${result.finishReason}` : ''}`,
+              content: result.text.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ')
+            }
+          };
+        } catch (error) {
+          console.error('Video analysis failed:', error);
+
+          if (error instanceof McpError) {
+            throw error;
+          }
+
+          throw new McpError(
+            ErrorCode.InternalError,
+            `Failed to analyze video: ${(error as Error).message}`
           );
         }
       }

--- a/src/twelvelabs-analyzer.ts
+++ b/src/twelvelabs-analyzer.ts
@@ -1,0 +1,93 @@
+import { TwelveLabs } from 'twelvelabs-js';
+
+/**
+ * Pegasus is TwelveLabs' video-understanding model. Unlike a transcript, which
+ * only captures spoken words, Pegasus reasons over what is actually shown on
+ * screen, so it can summarize or answer questions about videos that have little
+ * or no speech (demos, gameplay, b-roll, music videos, etc.).
+ *
+ * This module is an optional, self-contained adapter: it is only imported when
+ * the `analyze_video` tool is invoked, so the core transcript functionality
+ * keeps working with zero TwelveLabs configuration.
+ */
+
+export type PegasusModel = 'pegasus1.2' | 'pegasus1.5';
+
+export interface AnalyzeOptions {
+  /**
+   * A publicly reachable, direct video URL (e.g. an .mp4/.mov/.webm link or a
+   * pre-signed URL). TwelveLabs fetches the file server-side, so it must be a
+   * media file the platform can download — not a YouTube watch page, which
+   * serves HTML rather than a raw video stream.
+   */
+  url: string;
+  /** Natural-language instruction or question for the model. */
+  prompt: string;
+  /** Pegasus model to use. Defaults to `pegasus1.2`. */
+  model?: PegasusModel;
+  /** Maximum response length in tokens (2-4096 for pegasus1.2). Defaults to 2048. */
+  maxTokens?: number;
+}
+
+export interface AnalyzeResult {
+  text: string;
+  model: PegasusModel;
+  /** Why the model stopped, e.g. "stop" or "length". Present when returned by the API. */
+  finishReason?: string;
+}
+
+const DEFAULT_MODEL: PegasusModel = 'pegasus1.2';
+const DEFAULT_MAX_TOKENS = 2048;
+
+/**
+ * Reads the API key from the environment. Kept separate so callers can give a
+ * clear, actionable error before any network work happens.
+ */
+function getApiKey(): string {
+  const apiKey = process.env.TWELVELABS_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'TWELVELABS_API_KEY environment variable is not set. ' +
+        'Get a free key at https://twelvelabs.io and add it to your MCP server configuration.'
+    );
+  }
+  return apiKey;
+}
+
+/**
+ * Runs prompt-based video analysis with TwelveLabs Pegasus and returns the
+ * generated text. The client is created per-call so the module stays free of
+ * top-level side effects (the SDK throws if no key is present at construction).
+ */
+export async function analyzeVideo(options: AnalyzeOptions): Promise<AnalyzeResult> {
+  const { url, prompt } = options;
+  const model = options.model ?? DEFAULT_MODEL;
+  const maxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
+
+  if (!url) {
+    throw new Error('A video URL is required for analysis.');
+  }
+  if (!prompt) {
+    throw new Error('A prompt is required for analysis.');
+  }
+
+  const client = new TwelveLabs({ apiKey: getApiKey() });
+
+  const response = await client.analyze({
+    modelName: model,
+    video: { type: 'url', url },
+    prompt,
+    maxTokens,
+  });
+
+  const text = response.data;
+  if (typeof text !== 'string' || text.length === 0) {
+    throw new Error('TwelveLabs returned an empty analysis response.');
+  }
+
+  return {
+    text,
+    model,
+    finishReason: response.finishReason,
+  };
+}


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

A new **optional** `analyze_video` MCP tool that runs prompt-based video understanding via [TwelveLabs](https://twelvelabs.io) **Pegasus**. Where `get_transcript` only captures *spoken words*, Pegasus reasons over what is actually *shown on screen* — so it produces useful summaries and answers even for videos with little or no speech (product demos, gameplay, b-roll, music videos).

Inputs: `url` (a direct video URL), `prompt` (instruction/question, defaults to a general summary), `model` (`pegasus1.2` / `pegasus1.5`), and `max_tokens`. It returns both `content` text and `structuredContent`, matching the shape of the existing `get_transcript` tool.

## Why it helps this project

This server is the go-to MCP tool for getting *text out of videos*. Pegasus extends that from "what was said" to "what happened on screen", which is a natural complement for the summarize/QA workflows people already point at this server — and it covers the large set of videos that have poor or no captions.

## Opt-in / non-breaking

- The tool only activates when explicitly called and only then constructs a TwelveLabs client.
- It requires a `TWELVELABS_API_KEY` env var; without it, the existing transcript functionality is completely unchanged and needs zero TwelveLabs configuration.
- No existing tool, default, or behavior was modified.
- The official `twelvelabs-js` SDK is added as the single new dependency.

## How it was tested

- `npm run build` passes (strict TypeScript).
- A no-network unit check asserts the input-validation guards throw clearly.
- A live end-to-end call against Pegasus (`pegasus1.2`, a public sample `.mp4`) returns a correct on-screen summary, exercising the full `analyze({ video: { type: "url" }, prompt }) -> data` path.
- Added a matching `analyze_video` entry to the existing `mcp-evals` suite.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

> Note: TwelveLabs fetches the video server-side, so `url` must be a direct media file (`.mp4`/`.mov`/`.webm` or a pre-signed URL). A YouTube watch-page URL serves HTML, not a raw stream, so it isn't a valid input — this is documented in the tool description and README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 영상 URL을 입력해 화면 내용을 분석하고 요약·질문 응답을 받을 수 있는 새 동영상 분석 기능이 추가되었습니다.
  * 분석 모델 선택과 응답 길이 조절을 지원합니다.
* **Documentation**
  * 새 기능 사용 방법과 필요한 환경 설정이 문서에 추가되었습니다.
  * 직접 접근 가능한 영상 링크만 사용할 수 있다는 제한 사항이 안내되었습니다.
* **Dependencies**
  * 영상 분석 기능에 필요한 추가 라이브러리가 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->